### PR TITLE
Cluster identity across evaluations: refit-and-reconcile with MONIC transitions

### DIFF
--- a/Pipelines/src/Pipelines.jl
+++ b/Pipelines/src/Pipelines.jl
@@ -136,7 +136,8 @@ using StreamlinerCore:
 
 using Clustering: assignments, kmeans, dbscan, affinityprop
 
-using Distances: pairwise, SqEuclidean, Euclidean, Cityblock, Chebyshev, Minkowski,
+using Distances: Distances, Metric, UnionMinkowskiMetric,
+    pairwise, SqEuclidean, Euclidean, Cityblock, Chebyshev, Minkowski,
     WeightedSqEuclidean, WeightedEuclidean, WeightedCityblock, WeightedMinkowski
 
 using LinearAlgebra: diagind

--- a/Pipelines/src/cards/cluster.jl
+++ b/Pipelines/src/cards/cluster.jl
@@ -73,15 +73,62 @@ of clusters.
     tol::Float64 = 1.0e-6 & (dashi = json_number(exclusiveMinimum = 0),)
 end
 
+"""
+    _labels(res)
+
+Which cluster the fit put each ROW in. Most methods hand back a Clustering.jl
+result; a method that fits *transformed* data returns the per-row labels it
+mapped back itself.
+"""
+_labels(res) = assignments(res)
+_labels(labels::AbstractVector{<:Integer}) = labels
+
+"""
+    _collapse_duplicates(X)
+
+Distinct columns of `X` in first-occurrence order, how many rows each stands
+for, and the row -> distinct-point map.
+"""
+function _collapse_duplicates(X)
+    groups = OrderedDict{Vector{Float64}, Int}()
+    counts, row_group = Int[], Vector{Int}(undef, size(X, 2))
+    for (j, x) in enumerate(eachcol(X))
+        g = get!(groups, convert(Vector{Float64}, x)) do
+            push!(counts, 0)
+            length(counts)
+        end
+        counts[g] += 1
+        row_group[j] = g
+    end
+    return stack(keys(groups)), counts, row_group
+end
+
+#=
+Duplicate rows are collapsed into count weights before the fit. Repeated
+identical points otherwise keep affinity propagation's messages oscillating,
+and real data is full of them — calls from one address, readings from one
+sensor. The reduction is exact rather than a sample: similarities are scaled
+by the assignee's count so a distinct point pulls as hard as its copies would
+have, while the diagonal preferences stay unscaled, since a point is free to
+be its own exemplar however many copies it has, and the preference itself is
+the count-weighted median. Labels come back per distinct point, so they are
+expanded to the original rows before returning.
+=#
 function (m::AffinityPropagationMethod)(X; weights)
     (; damp, maxiter, tol) = m
     isnothing(weights) || @warn "Weights not supported in affinity propagation"
-    S = -pairwise(SqEuclidean(), X, dims = 2)
-    S[diagind(S)] .= vec(median(S, dims = 1))
+    U, counts, row_group = _collapse_duplicates(X)
+    # `affinityprop` needs at least two points; one distinct point is
+    # trivially its own exemplar
+    size(U, 2) == 1 && return ones(Int, size(X, 2))
+    S = -pairwise(SqEuclidean(), U, dims = 2)
+    p = [median(view(S, :, j), fweights(counts)) for j in axes(S, 2)]
+    S .*= counts
+    S[diagind(S)] .= p
     res = affinityprop(S; maxiter, tol, damp)
     res.converged ||
         @warn "Affinity propagation did not converge; increase `maxiter` or adjust `damp`"
-    return res
+    return assignments(res)[row_group]
 end
 
 const CLUSTERING_METHODS = OrderedDict{String, Type}(
@@ -123,7 +170,7 @@ function _train(cc::ClusterCard, t, id_var::AbstractPrimaryKey)
     X = stack(Fix1(getindex, t), cc.inputs, dims = 1)
     weights = isnothing(cc.weights) ? nothing : t[cc.weights]
     res = cc.method(X; weights)
-    label = assignments(res)
+    label = _labels(res)
     return (; label, id = t[id_var]) # return `label`s and relative `id`s for the evaluation
 end
 

--- a/Pipelines/src/cards/cluster.jl
+++ b/Pipelines/src/cards/cluster.jl
@@ -44,8 +44,10 @@ end
 DBSCAN (`"type" => "dbscan"`): density-based clusters of points within
 `radius` of each other, with the number of clusters coming from the data;
 sparse rows are labeled 0 (noise). The dissimilarity is restricted to
-[`MetricMethod`](@ref) — the KD-tree behind the fit requires the triangle
-inequality — so parsing and the schema only accept true metrics.
+[`MetricMethod`](@ref) — neighborhood queries rely on the triangle
+inequality — so parsing and the schema only accept true metrics. The
+Minkowski family is served by a KD-tree; any other metric goes in as a
+precomputed distance matrix, O(N²) in the fitted rows.
 """
 @kwarg struct DBSCANMethod{D <: MetricMethod} <: ClusteringMethod
     dissimilarity::D = EuclideanMethod()
@@ -58,6 +60,11 @@ function (m::DBSCANMethod)(X; weights)
     (; radius, min_neighbors, min_cluster_size) = m
     isnothing(weights) || @warn "Weights not supported in DBSCAN"
     metric = get_dissimilarity(m.dissimilarity)
+    metric isa UnionMinkowskiMetric ||
+        return dbscan(
+            pairwise(metric, X, dims = 2), radius;
+            metric = nothing, min_neighbors, min_cluster_size,
+        )
     return dbscan(X, radius; metric, min_neighbors, min_cluster_size)
 end
 

--- a/Pipelines/src/cards/cluster.jl
+++ b/Pipelines/src/cards/cluster.jl
@@ -154,10 +154,31 @@ const CLUSTERING_METHODS = OrderedDict{String, Type}(
         weights::Union{String, Nothing} = nothing
         partition::Union{String, Nothing} = nothing
         output::String = "cluster"
+        threshold::Float64 = 0.5
+        lineage::Bool = false
+        memory::Union{Int, Nothing} = nothing
     end
 
-Cluster `inputs` based on `method`.
-Save resulting column as `output`.
+Cluster `inputs` based on `method`. Save resulting column as `output`.
+
+Training keeps its members — the rows it saw, their `inputs`, and the label each
+received. Evaluation then **refits on those members plus whatever rows are new**
+and reconciles the two clusterings by shared membership, so a cluster keeps its
+identity from one evaluation to the next instead of being renumbered. No
+assignment rule could do this: training is transitive, whereas assigning against
+a frozen fit is one-shot, so a cluster could never grow.
+
+`threshold` is how much of a refit cluster's previously-labelled rows must come
+from one stored cluster for it to inherit that cluster's label; below it, the
+cluster is new. It is the sensitivity knob — high means more things count as new.
+
+`lineage` makes evaluation roll the stored members forward, so the model
+accumulates what it has seen. It is off by default because it makes evaluation
+stateful: the node is updated, and evaluating on new rows twice does not give
+the same answer. An evaluation that adds no rows changes nothing, so re-running
+one is always safe. `memory` bounds the accumulation, dropping members from more
+than that many iterations back — an iteration being a time the model actually
+grew.
 """
 @kwarg struct ClusterCard{M <: ClusteringMethod} <: StandardCard
     method::M
@@ -165,6 +186,9 @@ Save resulting column as `output`.
     weights::Union{String, Nothing} = nothing & (dashi = JSON_VARIABLE,)
     partition::Union{String, Nothing} = nothing & (dashi = JSON_VARIABLE,)
     output::String = "cluster" & (dashi = json_string(minLength = 1),)
+    threshold::Float64 = 0.5 & (dashi = json_number(exclusiveMinimum = 0, maximum = 1),)
+    lineage::Bool = false
+    memory::Union{Int, Nothing} = nothing & (dashi = json_integer(minimum = 1),)
 end
 
 ## StandardCard interface
@@ -173,19 +197,216 @@ SourceVariables(cc::ClusterCard) = SourceVariables(; cc.inputs, cc.weights, cc.p
 
 OutputVariables(cc::ClusterCard) = OutputVariables([cc.output])
 
+# Columns the member table adds to the card's own; an input of either name would
+# be shadowed, so `_member_table` refuses rather than silently overwrite.
+const MEMBER_LABEL = "label"
+const MEMBER_ORIGIN = "iteration_origin"
+
+"""
+    _diagnostics(method, res)
+
+Method-specific material worth keeping for *inspecting* a fit — a reachability
+graph, generative parameters, centers — as distinct from what evaluation needs,
+which is the member table. Methods opt in; by default nothing is kept.
+"""
+_diagnostics(::ClusteringMethod, res) = nothing
+
+"""
+    _member_columns(cc::ClusterCard, id_var)
+
+The columns a refit needs: the id, the inputs, and the weights column when there
+is one. Deduplicated, since `weights` may also be an input.
+"""
+function _member_columns(cc::ClusterCard, id_var::AbstractPrimaryKey)
+    cols = [id_var; cc.inputs]
+    isnothing(cc.weights) || push!(cols, cc.weights)
+    return unique(cols)
+end
+
+"""
+    _member_table(cc, t, id_var, label, origin)
+
+One row per fitted row: what a refit needs, plus the label the fit gave it and
+the iteration it entered the model on.
+"""
+function _member_table(cc::ClusterCard, t, id_var::AbstractPrimaryKey, label, origin::Integer)
+    cols = _member_columns(cc, id_var)
+    for reserved in (MEMBER_LABEL, MEMBER_ORIGIN)
+        reserved in cols && throw(
+            ArgumentError("`$reserved` is reserved by the cluster state; rename that column")
+        )
+    end
+    members = SimpleTable()
+    for col in cols
+        members[col] = t[col]
+    end
+    members[MEMBER_LABEL] = label
+    members[MEMBER_ORIGIN] = fill(Int(origin), length(label))
+    return members
+end
+
 function _train(cc::ClusterCard, t, id_var::AbstractPrimaryKey)
     X = stack(Fix1(getindex, t), cc.inputs, dims = 1)
     weights = isnothing(cc.weights) ? nothing : t[cc.weights]
     res = cc.method(X; weights)
     label = _labels(res)
-    return (; label, id = t[id_var]) # return `label`s and relative `id`s for the evaluation
+    return (;
+        members = _member_table(cc, t, id_var, label, 1),
+        diagnostics = _diagnostics(cc.method, res),
+        iteration = 1,
+        # labels are never reissued, so this must be the highest ever seen and
+        # not the highest currently present: a cluster dropped by `memory`
+        # must not lend its number to an unrelated one
+        highest_label = maximum(label; init = 0),
+    )
+end
+
+"""
+    _relabel_map(new_label, old_label, threshold, highest)
+
+Which stored label each refit cluster should carry, and the highest label issued
+once fresh ones are handed out.
+
+`old_label` covers the rows the stored fit had seen, aligned with the first
+`length(old_label)` entries of `new_label`. Noise (0) is not a cluster and takes
+no part in the correspondence. For each refit cluster, the stored cluster
+contributing most of its previously-labelled rows wins the label, provided that
+share reaches `threshold`; otherwise the cluster is an emergence and takes a
+fresh label. When several refit clusters claim the same stored one — a split —
+the largest keeps the label and the rest are fresh.
+
+Every scan runs in sorted order, so ties resolve to the lowest label rather than
+to whatever a `Dict` happened to iterate first: the result must depend on the
+data alone.
+"""
+function _relabel_map(new_label, old_label, threshold::Real, highest::Integer)
+    shared = min(length(old_label), length(new_label))
+    counts = Dict{Tuple{Int, Int}, Int}()   # (stored, refit) => shared rows
+    labelled = Dict{Int, Int}()             # refit cluster => its previously-labelled rows
+    @inbounds for i in 1:shared
+        o, n = old_label[i], new_label[i]
+        (o > 0 && n > 0) || continue
+        counts[(o, n)] = get(counts, (o, n), 0) + 1
+        labelled[n] = get(labelled, n, 0) + 1
+    end
+
+    stored = sort!(unique(o for o in old_label if o > 0))
+    refit = sort!(unique(n for n in new_label if n > 0))
+
+    claim = Dict{Int, Int}()                # refit cluster => stored cluster it claims
+    for n in refit
+        best_o, best_c = 0, 0
+        for o in stored                     # sorted: ties go to the lowest stored label
+            c = get(counts, (o, n), 0)
+            c > best_c && ((best_o, best_c) = (o, c))
+        end
+        best_o > 0 && best_c >= threshold * labelled[n] && (claim[n] = best_o)
+    end
+
+    keeper = Dict{Int, Int}()               # stored cluster => refit cluster keeping it
+    for n in refit                          # sorted: ties go to the lowest refit label
+        o = get(claim, n, 0)
+        o > 0 || continue
+        held = get(keeper, o, 0)
+        (held == 0 || counts[(o, n)] > counts[(o, held)]) && (keeper[o] = n)
+    end
+
+    map = Dict{Int, Int}(0 => 0)            # noise stays noise
+    next = Int(highest)
+    for n in refit
+        o = get(claim, n, 0)
+        if o > 0 && keeper[o] == n
+            map[n] = o
+        else
+            next += 1
+            map[n] = next
+        end
+    end
+    return map, next
+end
+
+# Rows of `t` the stored model has not seen. Order is `t`'s own, so the refit
+# input is deterministic.
+function _fresh_rows(members, t, id_var::AbstractPrimaryKey)
+    known = Set(members[id_var])
+    ids = t[id_var]
+    return [j for j in eachindex(ids) if !(ids[j] in known)]
+end
+
+function _refit_input(cc::ClusterCard, members, t, fresh)
+    stored = stack(Fix1(getindex, members), cc.inputs, dims = 1)
+    X = isempty(fresh) ? stored :
+        hcat(stored, stack(col -> t[col][fresh], cc.inputs, dims = 1))
+    weights = if isnothing(cc.weights)
+        nothing
+    else
+        vcat(members[cc.weights], t[cc.weights][fresh])
+    end
+    return X, weights
 end
 
 function (cc::ClusterCard)(model, t, id_var::AbstractPrimaryKey)
-    # as `predict` is not implemented, we cannot fill in data points outside partition
-    # https://github.com/JuliaStats/Clustering.jl/issues/63
-    # we simply return those used for the prediction with the correct indices
-    return SimpleTable(id_var => model.id, cc.output => model.label)
+    (; members) = model
+    fresh = _fresh_rows(members, t, id_var)
+    X, weights = _refit_input(cc, members, t, fresh)
+    new_label = _labels(cc.method(X; weights))
+
+    map, highest = _relabel_map(new_label, members[MEMBER_LABEL], cc.threshold, model.highest_label)
+    relabelled = [map[n] for n in new_label]
+
+    ids = vcat(members[id_var], t[id_var][fresh])
+    position = Dict(id => i for (i, id) in enumerate(ids))
+    labels = [relabelled[position[id]] for id in t[id_var]]
+    prediction = SimpleTable(id_var => t[id_var], cc.output => labels)
+
+    # Rolling forward on rows the model already had would spend an iteration
+    # without growing anything, and `memory` counts iterations — so an
+    # evaluation that adds nothing leaves the state alone and stays idempotent.
+    (cc.lineage && !isempty(fresh)) || return prediction
+    return prediction, CardState(
+        content = jldserialize(_roll_forward(cc, model, t, fresh, ids, relabelled, highest, id_var))
+    )
+end
+
+"""
+    _roll_forward(cc, model, t, fresh, ids, relabelled, highest, id_var)
+
+The state after a lineage-enabled evaluation: the stored members plus the rows
+this evaluation added, all carrying their reconciled labels. New rows are stamped
+with the new iteration, and `memory` drops members from iterations too old to
+keep. `highest_label` only ever grows, so a label freed by `memory` is not
+reissued.
+"""
+function _roll_forward(
+        cc::ClusterCard, model, t, fresh, ids, relabelled, highest::Integer,
+        id_var::AbstractPrimaryKey
+    )
+    (; members) = model
+    iteration = model.iteration + 1
+    origin = vcat(members[MEMBER_ORIGIN], fill(iteration, length(fresh)))
+
+    rolled = SimpleTable()
+    rolled[id_var] = ids
+    for col in _member_columns(cc, id_var)
+        col == id_var && continue
+        rolled[col] = vcat(members[col], t[col][fresh])
+    end
+    rolled[MEMBER_LABEL] = relabelled
+    rolled[MEMBER_ORIGIN] = origin
+
+    if !isnothing(cc.memory)
+        keep = findall(>=(iteration - cc.memory + 1), origin)
+        for (col, v) in rolled
+            rolled[col] = v[keep]
+        end
+    end
+
+    return (;
+        members = rolled,
+        model.diagnostics,
+        iteration,
+        highest_label = highest,
+    )
 end
 
 ## UI representation

--- a/Pipelines/src/cards/cluster.jl
+++ b/Pipelines/src/cards/cluster.jl
@@ -161,7 +161,8 @@ const CLUSTERING_METHODS = OrderedDict{String, Type}(
         weights::Union{String, Nothing} = nothing
         partition::Union{String, Nothing} = nothing
         output::String = "cluster"
-        threshold::Float64 = 0.5
+        match_threshold::Float64 = 0.5
+        split_threshold::Float64 = 0.25
         lineage::Bool = false
         memory::Union{Int, Nothing} = nothing
     end
@@ -175,9 +176,13 @@ identity from one evaluation to the next instead of being renumbered. No
 assignment rule could do this: training is transitive, whereas assigning against
 a frozen fit is one-shot, so a cluster could never grow.
 
-`threshold` is how much of a refit cluster's previously-labelled rows must come
-from one stored cluster for it to inherit that cluster's label; below it, the
-cluster is new. It is the sensitivity knob — high means more things count as new.
+The reconciliation follows MONIC's transition model (see [`_relabel_map`](@ref)):
+`match_threshold` is the fraction of a stored cluster's members that must land in a
+refit cluster for its label to survive there, and `split_threshold` the smaller
+fraction at which a refit cluster still counts as a piece of it when several
+pieces jointly reach `match_threshold` — the split case, where every piece keeps the
+label. Below both, correspondence is refused; high thresholds mean more things
+count as new.
 
 `lineage` makes evaluation roll the stored members forward, so the model
 accumulates what it has seen. It is off by default because it makes evaluation
@@ -193,7 +198,8 @@ grew.
     weights::Union{String, Nothing} = nothing & (dashi = JSON_VARIABLE,)
     partition::Union{String, Nothing} = nothing & (dashi = JSON_VARIABLE,)
     output::String = "cluster" & (dashi = json_string(minLength = 1),)
-    threshold::Float64 = 0.5 & (dashi = json_number(exclusiveMinimum = 0, maximum = 1),)
+    match_threshold::Float64 = 0.5 & (dashi = json_number(exclusiveMinimum = 0, maximum = 1),)
+    split_threshold::Float64 = 0.25 & (dashi = json_number(exclusiveMinimum = 0, maximum = 1),)
     lineage::Bool = false
     memory::Union{Int, Nothing} = nothing & (dashi = json_integer(minimum = 1),)
 end
@@ -269,60 +275,105 @@ function _train(cc::ClusterCard, t, id_var::AbstractPrimaryKey)
 end
 
 """
-    _relabel_map(new_label, old_label, threshold, highest)
+    _relabel_map(new_label, old_label, match_threshold, split_threshold, highest)
 
 Which stored label each refit cluster should carry, and the highest label issued
 once fresh ones are handed out.
 
 `old_label` covers the rows the stored fit had seen, aligned with the first
 `length(old_label)` entries of `new_label`. Noise (0) is not a cluster and takes
-no part in the correspondence. For each refit cluster, the stored cluster
-contributing most of its previously-labelled rows wins the label, provided that
-share reaches `threshold`; otherwise the cluster is an emergence and takes a
-fresh label. When several refit clusters claim the same stored one — a split —
-the largest keeps the label and the rest are fresh.
+no part in the correspondence.
 
-Every scan runs in sorted order, so ties resolve to the lowest label rather than
-to whatever a `Dict` happened to iterate first: the result must depend on the
-data alone.
+The correspondence follows MONIC's external transitions (Spiliopoulou, Ntoutsi,
+Theodoridis & Schult, *MONIC: Modeling and Monitoring Cluster Transitions*,
+KDD 2006), computed on the overlap of each STORED cluster with the refit:
+`overlap(o, n)` is the fraction of `o`'s members that landed in `n`. Members
+weigh equally — the card's `memory` window is MONIC's age function in its
+binary form: weight 1 inside the window, 0 beyond. Each stored cluster meets
+exactly one fate:
+
+- **survival / absorption** — its best match holds `overlap ≥ match_threshold` and
+  the label passes there; several stored clusters matching the same refit
+  cluster is an absorption (merge).
+- **split** — no single match suffices, but the refit clusters holding
+  `overlap ≥ split_threshold` jointly reach `match_threshold`: ALL of them are
+  descendants and carry the label, so a persistent event seen as several
+  pieces keeps one name.
+- **disappearance** — neither of the above; the label stops.
+
+A refit cluster no stored cluster passed into is an **emergence** and takes a
+fresh label, continuing past the highest ever issued — a forgotten cluster's
+number is never reused.
+
+MONIC emits a transition graph, not labels, so one convention is ours by
+necessity: a refit cluster with several ancestors (absorption, or ancestry
+through both a match and a split) is named by the ancestor that contributed
+most shared rows. Every scan runs in sorted order and ties resolve to the
+lowest label, so the result depends on the data alone.
 """
-function _relabel_map(new_label, old_label, threshold::Real, highest::Integer)
+function _relabel_map(
+        new_label, old_label, match_threshold::Real, split_threshold::Real, highest::Integer
+    )
+    0 < split_threshold <= match_threshold || throw(
+        ArgumentError("`split_threshold` must be in (0, `match_threshold`], got $split_threshold against $match_threshold")
+    )
     shared = min(length(old_label), length(new_label))
     counts = Dict{Tuple{Int, Int}, Int}()   # (stored, refit) => shared rows
-    labelled = Dict{Int, Int}()             # refit cluster => its previously-labelled rows
-    @inbounds for i in 1:shared
-        o, n = old_label[i], new_label[i]
-        (o > 0 && n > 0) || continue
+    sizes = Dict{Int, Int}()                # stored cluster => member count
+    # TODO: a recency-weighted age function — MONIC's aging in its smooth
+    # form — would count these per-member weights by the iteration each
+    # member entered on, so the newest pieces of a long-lived event weigh
+    # more in the overlap than its oldest ones.
+    @inbounds for i in eachindex(old_label)
+        o = old_label[i]
+        o > 0 || continue
+        sizes[o] = get(sizes, o, 0) + 1
+        i <= shared || continue
+        n = new_label[i]
+        n > 0 || continue
         counts[(o, n)] = get(counts, (o, n), 0) + 1
-        labelled[n] = get(labelled, n, 0) + 1
     end
 
-    stored = sort!(unique(o for o in old_label if o > 0))
+    stored = sort!(collect(keys(sizes)))
     refit = sort!(unique(n for n in new_label if n > 0))
 
-    claim = Dict{Int, Int}()                # refit cluster => stored cluster it claims
-    for n in refit
-        best_o, best_c = 0, 0
-        for o in stored                     # sorted: ties go to the lowest stored label
+    # stored cluster => the refit clusters it passes its label to
+    heirs = Dict{Int, Vector{Int}}()
+    for o in stored
+        best_n, best_c, joint = 0, 0, 0
+        children = Int[]
+        for n in refit                      # sorted: ties go to the lowest refit label
             c = get(counts, (o, n), 0)
-            c > best_c && ((best_o, best_c) = (o, c))
+            c > best_c && ((best_n, best_c) = (n, c))
+            if c >= split_threshold * sizes[o]
+                push!(children, n)
+                joint += c
+            end
         end
-        best_o > 0 && best_c >= threshold * labelled[n] && (claim[n] = best_o)
+        if best_c >= match_threshold * sizes[o]
+            heirs[o] = [best_n]
+        elseif !isempty(children) && joint >= match_threshold * sizes[o]
+            heirs[o] = children
+        end
     end
 
-    keeper = Dict{Int, Int}()               # stored cluster => refit cluster keeping it
-    for n in refit                          # sorted: ties go to the lowest refit label
-        o = get(claim, n, 0)
-        o > 0 || continue
-        held = get(keeper, o, 0)
-        (held == 0 || counts[(o, n)] > counts[(o, held)]) && (keeper[o] = n)
+    ancestor = Dict{Int, Int}()             # refit cluster => naming ancestor
+    strength = Dict{Int, Int}()             # refit cluster => that ancestor's shared rows
+    for o in stored                         # sorted: ties go to the lowest stored label
+        for n in get(() -> Int[], heirs, o)
+            c = counts[(o, n)]
+            if c > get(strength, n, 0)
+                ancestor[n] = o
+                strength[n] = c
+            end
+        end
     end
 
     map = Dict{Int, Int}(0 => 0)            # noise stays noise
     next = Int(highest)
     for n in refit
-        o = get(claim, n, 0)
-        if o > 0 && keeper[o] == n
+        o = get(ancestor, n, 0)
+        if o > 0
             map[n] = o
         else
             next += 1
@@ -358,7 +409,9 @@ function (cc::ClusterCard)(model, t, id_var::AbstractPrimaryKey)
     X, weights = _refit_input(cc, members, t, fresh)
     new_label = _labels(cc.method(X; weights))
 
-    map, highest = _relabel_map(new_label, members[MEMBER_LABEL], cc.threshold, model.highest_label)
+    map, highest = _relabel_map(
+        new_label, members[MEMBER_LABEL], cc.match_threshold, cc.split_threshold, model.highest_label
+    )
     relabelled = [map[n] for n in new_label]
 
     ids = vcat(members[id_var], t[id_var][fresh])

--- a/Pipelines/src/cards/cluster.jl
+++ b/Pipelines/src/cards/cluster.jl
@@ -23,12 +23,19 @@ usual convergence guarantee.
     iterations::Int = 100 & (dashi = json_integer(minimum = 1),)
     tol::Float64 = 1.0e-6 & (dashi = json_number(exclusiveMinimum = 0),)
     seed::Union{Int, Nothing} = nothing & (dashi = json_integer(minimum = 0),)
+    # how the initial centers are seeded: k-means++, uniformly at random, or
+    # the points of extreme centrality (Clustering.jl's :kmpp/:rand/:kmcen)
+    init::String = "kmpp" & (dashi = json_string(enum = ["kmpp", "rand", "kmcen"]),)
 end
 
 function (m::KMeansMethod)(X; weights)
     (; classes, iterations, tol, seed) = m
     distance = get_dissimilarity(m.dissimilarity)
-    return kmeans(X, classes; maxiter = iterations, tol, rng = get_rng(seed), weights, distance)
+    return kmeans(
+        X, classes;
+        maxiter = iterations, tol, rng = get_rng(seed), weights, distance,
+        init = Symbol(m.init),
+    )
 end
 
 """

--- a/Pipelines/src/cards/standard.jl
+++ b/Pipelines/src/cards/standard.jl
@@ -1,6 +1,13 @@
 # StandardCard interface:
 # - `_train(c, tbl, id; weights) -> model`
-# - `(c)(model, tbl, id) -> new_tbl, new_id`
+# - `(c)(model, tbl, id) -> new_tbl`
+#
+# A card whose evaluation also rolls its state forward returns
+# `(new_tbl, state)`; `evaluate` then returns `(columns, state)` and the node
+# stores it (see `_persist_state!` in node.jl). Everything else is untouched.
+
+_with_state(prediction) = (prediction, nothing)
+_with_state((prediction, state)::Tuple{SimpleTable, CardState}) = (prediction, state)
 
 # Implementation of Card methods
 
@@ -39,8 +46,9 @@ function evaluate(
     t = DBInterface.execute(fromtable, repository, q; schema)
 
     model = jlddeserialize(state.content)
-    pred_table = c(model, t, id_var)
+    pred_table, new_state = _with_state(c(model, t, id_var))
     load_table(repository, pred_table, destination; schema)
     cols = String[string(k) for k in Tables.columnnames(Tables.columns(pred_table))]
-    return setdiff(cols, [id_var])
+    columns = setdiff(cols, [id_var])
+    return isnothing(new_state) ? columns : (columns, new_state)
 end

--- a/Pipelines/src/dissimilarities.jl
+++ b/Pipelines/src/dissimilarities.jl
@@ -130,6 +130,64 @@ card's `inputs` in length and order.
 end
 
 """
+    ConjunctiveMethod <: MetricMethod
+
+Conjunctive distance (`"type" => "conjunctive"`): `blocks` assigns each of
+the card's `inputs` to a block, `radii` gives each block its own radius, and
+the distance is the largest within-block Euclidean distance divided by that
+block's radius. Two points are close only when close in every block at once,
+so no exchange rate between the blocks' units is ever asserted — with inputs
+`[east, north, minutes]`, `blocks = [1, 1, 2]` and `radii = [5.0, 60.0]`
+reads "within 5 km and within 60 minutes". Distances are dimensionless: 1
+means "at the radius in the worst block". A maximum of metrics is again a
+metric, hence a true [`MetricMethod`](@ref).
+"""
+@kwarg struct ConjunctiveMethod <: MetricMethod
+    blocks::Vector{Int} & (
+        dashi = json_array(items = json_integer(minimum = 1), minItems = 1),
+    )
+    radii::Vector{Float64} & (
+        dashi = json_array(items = json_number(exclusiveMinimum = 0), minItems = 1),
+    )
+end
+
+"""
+    Conjunctive(groups, radii, dims)
+
+The Distances.jl object behind [`ConjunctiveMethod`](@ref): `groups` lists
+the coordinate indices of each block, `radii` its radius, `dims` the
+coordinate count every evaluated pair must have.
+"""
+struct Conjunctive <: Metric
+    groups::Vector{Vector{Int}}
+    radii::Vector{Float64}
+    dims::Int
+end
+
+function (dist::Conjunctive)(a, b)
+    length(a) == length(b) == dist.dims || throw(
+        DimensionMismatch(
+            "conjunctive metric over $(dist.dims) coordinates, got $(length(a)) and $(length(b))"
+        )
+    )
+    worst = 0.0
+    for (g, r) in zip(dist.groups, dist.radii)
+        s = 0.0
+        @inbounds for k in g
+            δ = a[k] - b[k]
+            s += δ * δ
+        end
+        d = sqrt(s) / r
+        d > worst && (worst = d)
+    end
+    return worst
+end
+
+# the generic fallback probes the metric on two scalars, which the dimension
+# check above refuses
+Distances.result_type(::Conjunctive, ::Type, ::Type) = Float64
+
+"""
     get_dissimilarity(m::DissimilarityMethod)
 
 The Distances.jl object a `DissimilarityMethod` configures — usable
@@ -147,6 +205,16 @@ get_dissimilarity(m::WeightedEuclideanMethod) = WeightedEuclidean(m.weights)
 get_dissimilarity(m::WeightedCityblockMethod) = WeightedCityblock(m.weights)
 get_dissimilarity(m::WeightedMinkowskiMethod) = WeightedMinkowski(m.weights, m.p)
 
+function get_dissimilarity(m::ConjunctiveMethod)
+    (; blocks, radii) = m
+    sort(unique(blocks)) == eachindex(radii) || throw(
+        ArgumentError("`blocks` must number the blocks 1:$(length(radii)), got $(sort(unique(blocks)))")
+    )
+    all(>(0), radii) || throw(ArgumentError("`radii` must be positive, got $radii"))
+    groups = [findall(==(b), blocks) for b in eachindex(radii)]
+    return Conjunctive(groups, radii, length(blocks))
+end
+
 """
     METRIC_METHODS
 
@@ -162,6 +230,7 @@ const METRIC_METHODS = OrderedDict{String, Type}(
     "weighted_euclidean" => WeightedEuclideanMethod,
     "weighted_cityblock" => WeightedCityblockMethod,
     "weighted_minkowski" => WeightedMinkowskiMethod,
+    "conjunctive" => ConjunctiveMethod,
 )
 
 """

--- a/Pipelines/src/node.jl
+++ b/Pipelines/src/node.jl
@@ -163,7 +163,7 @@ Then save the output in table `destination`.
 
 A card that rolls its state forward as it evaluates may return
 `(columns, state)` instead of `columns`; the new state is then stored in the
-node. See [`_persist_state!`](@ref).
+node. See `_persist_state!`.
 """
 function evaluate(
         repository::Repository, node::Node,

--- a/Pipelines/src/node.jl
+++ b/Pipelines/src/node.jl
@@ -160,6 +160,10 @@ end
 Evaluate the card corresponding to a given `node` (using the node's state)
 on table `source` with primary column `id_var`.
 Then save the output in table `destination`.
+
+A card that rolls its state forward as it evaluates may return
+`(columns, state)` instead of `columns`; the new state is then stored in the
+node. See [`_persist_state!`](@ref).
 """
 function evaluate(
         repository::Repository, node::Node,
@@ -167,9 +171,31 @@ function evaluate(
         schema::Union{AbstractString, Nothing} = nothing
     )
     card, state = get_card(node), get_state(node)
-    return if get_invert(node)
+    result = if get_invert(node)
         evaluate(repository, card, state, sd, id_var; schema, invert = true)
     else
         evaluate(repository, card, state, sd, id_var; schema)
     end
+    return _persist_state!(node, result)
+end
+
+"""
+    _persist_state!(node::Node, result)
+
+Unwrap what a card's `evaluate` returned. Cards return their output columns and
+this passes them through untouched; a card that also rolls its state forward
+returns `(columns, state)`, and that state is stored in `node`.
+
+The pass-through is untyped because it must accept whatever any card returns.
+The tuple method is typed exactly, since the only cards producing one are those
+opting into this behaviour: `CardState` is what [`set_state!`](@ref) can store,
+and `Vector{String}` is the column contract `evaljoin` relies on. Anything else
+— including a tuple of other types — falls through to the pass-through rather
+than being mistaken for a state update.
+"""
+_persist_state!(::Node, result) = result
+
+function _persist_state!(node::Node, (columns, state)::Tuple{Vector{String}, CardState})
+    set_state!(node, state)
+    return columns
 end

--- a/Pipelines/src/structs/json_schema.jl
+++ b/Pipelines/src/structs/json_schema.jl
@@ -8,7 +8,10 @@ function schema_from_type(T::Type)
     end
 
     # we consider nullable types, which correspond to optional fields with no default
-    type = (T <: Union{Integer, Nothing}) ? "integer" :
+    # `Bool <: Integer` in Julia, so it must be recognized before the integer
+    # branch or a boolean field would demand an integer and reject its own value
+    type = (T <: Union{Bool, Nothing}) ? "boolean" :
+        (T <: Union{Integer, Nothing}) ? "integer" :
         (T <: Union{Number, Nothing}) ? "number" :
         (T <: Union{AbstractString, Symbol, Nothing}) ? "string" :
         (T <: Union{AbstractVector, Nothing}) ? "array" :

--- a/Pipelines/test/cards.jl
+++ b/Pipelines/test/cards.jl
@@ -414,6 +414,103 @@ end
     @test all(==(1), per_point.k)
 end
 
+@testset "cluster reconciliation" begin
+    d = JSON.parsefile(joinpath(@__DIR__, "static", "configs", "cluster.json"))
+
+    # The matcher on hand-written fits. Density refits can only grow clusters
+    # (an added point never separates two others), so the split, merge and
+    # threshold branches are exercised here directly.
+    relabel = Pipelines._relabel_map
+
+    # an identical refit: every cluster keeps its label, noise stays noise
+    m, highest = relabel([1, 1, 2, 2, 0], [1, 1, 2, 2, 0], 0.5, 2)
+    @test m == Dict(0 => 0, 1 => 1, 2 => 2)
+    @test highest == 2
+
+    # inheritance follows membership, not the refit's numbering
+    m, _ = relabel([2, 2, 1, 1], [1, 1, 2, 2], 0.5, 2)
+    @test m[2] == 1 && m[1] == 2
+
+    # split: the larger piece keeps the label, the smaller is an emergence
+    m, highest = relabel([1, 1, 1, 4, 4, 2, 2], [1, 1, 1, 1, 1, 2, 2], 0.5, 2)
+    @test m[1] == 1 && m[4] == 3 && m[2] == 2
+    @test highest == 3
+
+    # merge: the union inherits from its largest contributor (ties to the lowest)
+    m, _ = relabel([1, 1, 1, 1], [1, 1, 2, 2], 0.5, 2)
+    @test m[1] == 1
+
+    # rows the stored fit never saw cannot claim a label...
+    m, _ = relabel([1, 1, 2, 2], [1, 1], 0.5, 2)
+    @test m[1] == 1 && m[2] == 3
+
+    # ...and fresh labels continue from the highest ever issued, not the
+    # highest present, so a forgotten cluster's number is never reused
+    m, highest = relabel([1, 1, 2, 2], [1, 1], 0.5, 7)
+    @test m[2] == 8 && highest == 8
+
+    # the threshold is the share of previously-labelled rows the winner holds
+    @test relabel([3, 3, 3, 3], [1, 2, 2, 2], 0.5, 3)[1][3] == 2   # 3/4 suffices
+    @test relabel([3, 3, 3, 3], [1, 2, 2, 2], 0.8, 3)[1][3] == 4   # 3/4 < 0.8
+
+    # The shared refit-and-reconcile evaluation, on three tight well-separated
+    # blobs plus a fourth far away to add later.
+    blob(cx, cy, k) = DataFrame(
+        id = k .+ (1:9),
+        x = [cx + 0.1 * (i % 3) for i in 1:9],
+        y = [cy + 0.1 * (i ÷ 3) for i in 1:9],
+    )
+    base = reduce(vcat, [blob(0.0, 0.0, 0), blob(10.0, 0.0, 100), blob(0.0, 10.0, 200)])
+    grown = vcat(base, blob(30.0, 30.0, 300))
+    DuckDBUtils.load_table(repo, base, "recon_base")
+    DuckDBUtils.load_table(repo, grown, "recon_grown")
+
+    reconcile_state(node) = Pipelines.jlddeserialize(Pipelines.get_state(node).content)
+
+    node = Node(Pipelines.Card(d["reconcile"]))
+    Pipelines.train_evaljoin!(repo, node, "recon_base" => "recon_out", "id")
+    fitted = DBInterface.execute(DataFrame, repo, "FROM recon_out ORDER BY id").cluster
+    @test sort(unique(fitted)) == [1, 2, 3]
+
+    # refitting on unchanged data produces no transitions
+    Pipelines.evaljoin(repo, node, "recon_base" => "recon_again", "id")
+    again = DBInterface.execute(DataFrame, repo, "FROM recon_again ORDER BY id")
+    @test again.cluster == fitted
+
+    # a far-away blob is an emergence: one fresh label, old labels untouched
+    Pipelines.evaljoin(repo, node, "recon_grown" => "recon_emerged", "id")
+    emerged = DBInterface.execute(DataFrame, repo, "FROM recon_emerged ORDER BY id")
+    @test emerged.cluster[emerged.id .< 300] == fitted
+    @test unique(emerged.cluster[emerged.id .> 300]) == [maximum(fitted) + 1]
+    # with lineage off both evaluations left the state alone
+    @test reconcile_state(node).iteration == 1
+    @test length(reconcile_state(node).members["label"]) == nrow(base)
+
+    # lineage on: an evaluation that admits rows rolls the members forward,
+    # stamping the iteration they arrived in
+    node = Node(Pipelines.Card(merge(d["reconcile"], Dict("lineage" => true))))
+    Pipelines.train_evaljoin!(repo, node, "recon_base" => "recon_out", "id")
+    Pipelines.evaljoin(repo, node, "recon_grown" => "recon_emerged", "id")
+    st = reconcile_state(node)
+    @test st.iteration == 2
+    @test length(st.members["label"]) == nrow(grown)
+    @test sort(unique(st.members["iteration_origin"])) == [1, 2]
+
+    # ...but one that admits nothing is a no-op: iterations measure growth,
+    # so re-running an evaluation cannot age the members
+    Pipelines.evaljoin(repo, node, "recon_grown" => "recon_noop", "id")
+    @test reconcile_state(node).iteration == 2
+
+    # memory keeps only the newest iterations, without reissuing freed labels
+    node = Node(Pipelines.Card(merge(d["reconcile"], Dict("lineage" => true, "memory" => 1))))
+    Pipelines.train_evaljoin!(repo, node, "recon_base" => "recon_out", "id")
+    Pipelines.evaljoin(repo, node, "recon_grown" => "recon_emerged", "id")
+    st = reconcile_state(node)
+    @test unique(st.members["iteration_origin"]) == [2]
+    @test length(st.members["label"]) == nrow(grown) - nrow(base)
+    @test st.highest_label == maximum(fitted) + 1
+end
+
 @testset "dimensionality reduction" begin
     d = JSON.parsefile(joinpath(@__DIR__, "static", "configs", "dimensionality_reduction.json"))
 

--- a/Pipelines/test/cards.jl
+++ b/Pipelines/test/cards.jl
@@ -314,6 +314,19 @@ end
     )
     @test assignments(R) == df.cbcluster
 
+    # the configured seeding reaches the fit
+    card = Pipelines.Card(d["kmeansInit"])
+    node = Node(card)
+    Pipelines.train_evaljoin!(repo, node, "selection" => "clustering", "No")
+    df = DBInterface.execute(DataFrame, repo, "FROM clustering")
+    train_df = DBInterface.execute(DataFrame, repo, "FROM selection")
+    rng = StreamlinerCore.get_rng(1234)
+    R = kmeans(
+        [train_df.TEMP train_df.PRES train_df.Iws]', 3;
+        maxiter = 100, tol = 1.0e-6, rng, weights = train_df.Iws, init = :rand,
+    )
+    @test assignments(R) == df.initcluster
+
     card = Pipelines.Card(d["dbscan"])
     @test !Pipelines.invertible(card)
 

--- a/Pipelines/test/cards.jl
+++ b/Pipelines/test/cards.jl
@@ -373,6 +373,32 @@ end
     R = affinityprop(S; maxiter = 200, tol = 1.0e-6, damp = 0.5)
     @test R.converged
     @test df.apcluster == assignments(R)
+
+    # the same fit WITHOUT the hand-deduplication: duplicates are collapsed
+    # into count weights inside the method, so identical points no longer
+    # keep the messages oscillating and every row still comes back labeled
+    DBInterface.execute(
+        Returns(nothing),
+        repo,
+        "CREATE OR REPLACE TABLE cl_dup AS (FROM selection LIMIT 200);"
+    )
+    counts = DBInterface.execute(
+        DataFrame, repo,
+        "SELECT count(*) AS n, count(DISTINCT (\"TEMP\", \"PRES\")) AS distinct_points FROM cl_dup"
+    )
+    @test counts.distinct_points[1] < counts.n[1]   # otherwise the test is vacuous
+
+    node = Node(Pipelines.Card(d["affinity"]))
+    Pipelines.train_evaljoin!(repo, node, "cl_dup" => "clustering_dup", "No")
+    dup = DBInterface.execute(DataFrame, repo, "FROM clustering_dup")
+    @test nrow(dup) == counts.n[1]
+    @test all(>(0), dup.apcluster)
+    # identical points must share a cluster
+    per_point = DBInterface.execute(
+        DataFrame, repo,
+        "SELECT count(DISTINCT apcluster) AS k FROM clustering_dup GROUP BY \"TEMP\", \"PRES\""
+    )
+    @test all(==(1), per_point.k)
 end
 
 @testset "dimensionality reduction" begin

--- a/Pipelines/test/cards.jl
+++ b/Pipelines/test/cards.jl
@@ -511,6 +511,117 @@ end
     @test st.highest_label == maximum(fitted) + 1
 end
 
+@testset "conjunctive metric" begin
+    d = JSON.parsefile(joinpath(@__DIR__, "static", "configs", "cluster.json"))
+
+    # the metric itself: the largest within-block Euclidean over its radius
+    conj = Pipelines.get_dissimilarity(
+        Pipelines.ConjunctiveMethod(blocks = [1, 1, 2], radii = [5.0, 60.0])
+    )
+    @test conj([0.0, 0.0, 0.0], [3.0, 4.0, 0.0]) == 1.0     # 5 km at radius 5
+    @test conj([0.0, 0.0, 0.0], [0.0, 0.0, 60.0]) == 1.0    # 60 min at radius 60
+    @test conj([0.0, 0.0, 0.0], [3.0, 4.0, 30.0]) == 1.0    # max never trades
+    @test conj([0.0, 0.0, 0.0], [0.0, 3.0, 30.0]) == 0.6
+    @test conj([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == 0.0
+
+    # malformed specs stop at the gate
+    @test_throws ArgumentError Pipelines.get_dissimilarity(
+        Pipelines.ConjunctiveMethod(blocks = [1, 3], radii = [1.0, 2.0])    # gapped numbering
+    )
+    @test_throws ArgumentError Pipelines.get_dissimilarity(
+        Pipelines.ConjunctiveMethod(blocks = [1, 1], radii = [0.0])         # not a radius
+    )
+    @test_throws DimensionMismatch conj([0.0, 0.0], [1.0, 1.0])             # two coordinates for three
+
+    #=
+    Two groups with IDENTICAL internal distance structure: P holds one place
+    across 40 minutes, Q holds one minute across 40 km. Every Minkowski metric
+    sees two isometric sets and must label them alike, whatever its
+    parameters. The conjunctive metric is not obliged to, and that is the
+    whole point of it: within 5 km AND within 60 minutes makes P one
+    neighbourhood and Q five isolated points.
+    =#
+    steps = collect(0.0:10.0:40.0)
+    pq = DataFrame(
+        id = 1:10,
+        x = vcat(zeros(5), steps),
+        y = vcat(zeros(5), fill(1000.0, 5)),
+        z = vcat(steps, zeros(5)),
+    )
+    DuckDBUtils.load_table(repo, pq, "conj_pq")
+
+    node = Node(Pipelines.Card(d["conjunctive"]))
+    Pipelines.train_evaljoin!(repo, node, "conj_pq" => "conj_out", "id")
+    labels = DBInterface.execute(DataFrame, repo, "FROM conj_out ORDER BY id").cluster
+    @test labels[1:5] == fill(1, 5)
+    @test labels[6:10] == zeros(Int, 5)
+
+    euclid = merge(
+        d["conjunctive"],
+        Dict("method" => Dict(
+            "type" => "dbscan", "radius" => 25.0, "min_neighbors" => 3, "min_cluster_size" => 3,
+        )),
+    )
+    node = Node(Pipelines.Card(euclid))
+    Pipelines.train_evaljoin!(repo, node, "conj_pq" => "conj_out", "id")
+    labels = DBInterface.execute(DataFrame, repo, "FROM conj_out ORDER BY id").cluster
+    @test labels[1:5] == fill(1, 5)
+    @test labels[6:10] == fill(2, 5)
+
+    # the same dissimilarity reaches kmeans through the shared field — which
+    # method-local options never could
+    kmconj = merge(
+        d["conjunctive"],
+        Dict("method" => Dict(
+            "type" => "kmeans", "classes" => 2, "seed" => 1234,
+            "dissimilarity" => d["conjunctive"]["method"]["dissimilarity"],
+        )),
+    )
+    node = Node(Pipelines.Card(kmconj))
+    Pipelines.train_evaljoin!(repo, node, "conj_pq" => "conj_out", "id")
+    labels = DBInterface.execute(DataFrame, repo, "FROM conj_out ORDER BY id").cluster
+    @test allunique(labels[[1, 6]]) && labels[1:5] == fill(labels[1], 5) && labels[6:10] == fill(labels[6], 5)
+
+    # one block of radius 1 IS the Euclidean default; and dividing every
+    # radius and the cut by the same factor leaves the labeling alone
+    xy = DataFrame(
+        id = 1:18,
+        x = [cx + 0.1 * (i % 3) for cx in (0.0, 10.0) for i in 1:9],
+        y = [0.1 * (i ÷ 3) for _ in (0.0, 10.0) for i in 1:9],
+    )
+    DuckDBUtils.load_table(repo, xy, "conj_xy")
+    node = Node(Pipelines.Card(d["reconcile"]))
+    Pipelines.train_evaljoin!(repo, node, "conj_xy" => "conj_base", "id")
+    base = DBInterface.execute(DataFrame, repo, "FROM conj_base ORDER BY id").cluster
+    @test sort(unique(base)) == [1, 2]
+
+    unit_block = Dict("type" => "conjunctive", "blocks" => [1, 1], "radii" => [1.0])
+    unit = merge(d["reconcile"], Dict("method" => merge(d["reconcile"]["method"], Dict("dissimilarity" => unit_block))))
+    node = Node(Pipelines.Card(unit))
+    Pipelines.train_evaljoin!(repo, node, "conj_xy" => "conj_unit", "id")
+    @test DBInterface.execute(DataFrame, repo, "FROM conj_unit ORDER BY id").cluster == base
+
+    scaled_block = Dict("type" => "conjunctive", "blocks" => [1, 1], "radii" => [2.0])
+    scaled = merge(
+        d["reconcile"],
+        Dict("method" => merge(d["reconcile"]["method"], Dict("radius" => 0.5, "dissimilarity" => scaled_block))),
+    )
+    node = Node(Pipelines.Card(scaled))
+    Pipelines.train_evaljoin!(repo, node, "conj_xy" => "conj_scaled", "id")
+    @test DBInterface.execute(DataFrame, repo, "FROM conj_scaled ORDER BY id").cluster == base
+
+    # a block per input is required once the metric meets the data
+    bad = merge(
+        d["reconcile"],
+        Dict("method" => merge(
+            d["reconcile"]["method"],
+            Dict("dissimilarity" => d["conjunctive"]["method"]["dissimilarity"]),
+        )),
+    )
+    node = Node(Pipelines.Card(bad))
+    @test_throws DimensionMismatch Pipelines.train_evaljoin!(repo, node, "conj_xy" => "conj_bad", "id")
+end
+
 @testset "dimensionality reduction" begin
     d = JSON.parsefile(joinpath(@__DIR__, "static", "configs", "dimensionality_reduction.json"))
 

--- a/Pipelines/test/cards.jl
+++ b/Pipelines/test/cards.jl
@@ -417,41 +417,61 @@ end
 @testset "cluster reconciliation" begin
     d = JSON.parsefile(joinpath(@__DIR__, "static", "configs", "cluster.json"))
 
-    # The matcher on hand-written fits. Density refits can only grow clusters
-    # (an added point never separates two others), so the split, merge and
-    # threshold branches are exercised here directly.
+    # The matcher on hand-written fits, one case per MONIC transition
+    # (survival, absorption, split, disappearance, emergence). Density refits
+    # can only grow clusters — an added point never separates two others — so
+    # the split and disappearance branches are exercised here directly.
     relabel = Pipelines._relabel_map
 
-    # an identical refit: every cluster keeps its label, noise stays noise
-    m, highest = relabel([1, 1, 2, 2, 0], [1, 1, 2, 2, 0], 0.5, 2)
+    # survival: every cluster keeps its label, noise stays noise
+    m, highest = relabel([1, 1, 2, 2, 0], [1, 1, 2, 2, 0], 0.5, 0.25, 2)
     @test m == Dict(0 => 0, 1 => 1, 2 => 2)
     @test highest == 2
 
-    # inheritance follows membership, not the refit's numbering
-    m, _ = relabel([2, 2, 1, 1], [1, 1, 2, 2], 0.5, 2)
+    # survival follows membership, not the refit's numbering
+    m, _ = relabel([2, 2, 1, 1], [1, 1, 2, 2], 0.5, 0.25, 2)
     @test m[2] == 1 && m[1] == 2
 
-    # split: the larger piece keeps the label, the smaller is an emergence
-    m, highest = relabel([1, 1, 1, 4, 4, 2, 2], [1, 1, 1, 1, 1, 2, 2], 0.5, 2)
-    @test m[1] == 1 && m[4] == 3 && m[2] == 2
+    # survival preempts split: the best match holds ≥ match_threshold of the
+    # stored cluster on its own, so the smaller shard is an emergence
+    m, highest = relabel([1, 1, 1, 4, 4, 2, 2], [1, 1, 1, 1, 1, 2, 2], 0.5, 0.25, 2)
+    @test m[1] == 1 && m[2] == 2 && m[4] == 3
     @test highest == 3
 
-    # merge: the union inherits from its largest contributor (ties to the lowest)
-    m, _ = relabel([1, 1, 1, 1], [1, 1, 2, 2], 0.5, 2)
+    # split: no single piece reaches the match_threshold, but the pieces holding
+    # ≥ split_threshold jointly do — ALL of them are descendants and keep
+    # the label, so an event seen as several pieces keeps one name
+    m, highest = relabel([1, 1, 1, 4, 4, 2, 2], [1, 1, 1, 1, 1, 2, 2], 0.7, 0.25, 2)
+    @test m[1] == 1 && m[4] == 1 && m[2] == 2
+    @test highest == 2
+
+    # a shard below split_threshold is no descendant: it emerges fresh
+    m, _ = relabel([1, 1, 1, 1, 4, 4, 4, 4, 4, 6], fill(1, 10), 0.6, 0.25, 2)
+    @test m[1] == 1 && m[4] == 1 && m[6] == 3
+
+    # absorption: the union is named by the dominant contributor...
+    m, _ = relabel([7, 7, 7, 7, 7], [1, 1, 1, 2, 2], 0.5, 0.25, 7)
+    @test m[7] == 1
+    # ...and equal contributions resolve to the lowest label
+    m, _ = relabel([1, 1, 1, 1], [1, 1, 2, 2], 0.5, 0.25, 2)
     @test m[1] == 1
 
-    # rows the stored fit never saw cannot claim a label...
-    m, _ = relabel([1, 1, 2, 2], [1, 1], 0.5, 2)
-    @test m[1] == 1 && m[2] == 3
+    # disappearance: members scattered below split_threshold leave no heir,
+    # and the freed number is never reissued — fresh labels continue past
+    # the highest ever issued
+    m, highest = relabel([3, 4, 5, 6, 7], fill(1, 5), 0.5, 0.25, 9)
+    @test [m[n] for n in 3:7] == [10, 11, 12, 13, 14]
+    @test highest == 14
 
-    # ...and fresh labels continue from the highest ever issued, not the
-    # highest present, so a forgotten cluster's number is never reused
-    m, highest = relabel([1, 1, 2, 2], [1, 1], 0.5, 7)
+    # emergence: rows the stored fit never saw cannot claim a label
+    m, _ = relabel([1, 1, 2, 2], [1, 1], 0.5, 0.25, 2)
+    @test m[1] == 1 && m[2] == 3
+    m, highest = relabel([1, 1, 2, 2], [1, 1], 0.5, 0.25, 7)
     @test m[2] == 8 && highest == 8
 
-    # the threshold is the share of previously-labelled rows the winner holds
-    @test relabel([3, 3, 3, 3], [1, 2, 2, 2], 0.5, 3)[1][3] == 2   # 3/4 suffices
-    @test relabel([3, 3, 3, 3], [1, 2, 2, 2], 0.8, 3)[1][3] == 4   # 3/4 < 0.8
+    # `split_threshold` is a fraction bounded by `match_threshold`
+    @test_throws ArgumentError relabel([1], [1], 0.5, 0.6, 1)
+    @test_throws ArgumentError relabel([1], [1], 0.5, 0.0, 1)
 
     # The shared refit-and-reconcile evaluation, on three tight well-separated
     # blobs plus a fourth far away to add later.

--- a/Pipelines/test/schemas.jl
+++ b/Pipelines/test/schemas.jl
@@ -88,6 +88,16 @@ end
     _pipeline_schema_validate(schema, reconcile)
     _pipeline_schema_invalidate(schema, merge(reconcile, Dict("threshold" => 1.5)))
     _pipeline_schema_invalidate(schema, merge(reconcile, Dict("memory" => 0)))
+    # the conjunctive metric is a true metric, so dbscan's field accepts it;
+    # radii are positive and required
+    conjunctive = merge(d["conjunctive"], Dict("inputs" => ["TEMP", "PRES", "Iws"]))
+    _pipeline_schema_validate(schema, conjunctive)
+    zero_radius = deepcopy(conjunctive)
+    zero_radius["method"]["dissimilarity"]["radii"] = [5.0, 0.0]
+    _pipeline_schema_invalidate(schema, zero_radius)
+    no_radii = deepcopy(conjunctive)
+    delete!(no_radii["method"]["dissimilarity"], "radii")
+    _pipeline_schema_invalidate(schema, no_radii)
 end
 
 @testset "dimensionality reduction schema" begin

--- a/Pipelines/test/schemas.jl
+++ b/Pipelines/test/schemas.jl
@@ -80,6 +80,14 @@ end
     spurious_property = deepcopy(d["dbscan"])
     spurious_property["method"]["minneighbors"] = 10
     _pipeline_schema_invalidate(schema, spurious_property)
+    # the reconciliation options: threshold in (0, 1], memory ≥ 1
+    reconcile = merge(
+        d["reconcile"],
+        Dict("inputs" => ["TEMP", "PRES"], "threshold" => 0.75, "lineage" => true, "memory" => 2),
+    )
+    _pipeline_schema_validate(schema, reconcile)
+    _pipeline_schema_invalidate(schema, merge(reconcile, Dict("threshold" => 1.5)))
+    _pipeline_schema_invalidate(schema, merge(reconcile, Dict("memory" => 0)))
 end
 
 @testset "dimensionality reduction schema" begin

--- a/Pipelines/test/schemas.jl
+++ b/Pipelines/test/schemas.jl
@@ -80,13 +80,17 @@ end
     spurious_property = deepcopy(d["dbscan"])
     spurious_property["method"]["minneighbors"] = 10
     _pipeline_schema_invalidate(schema, spurious_property)
-    # the reconciliation options: threshold in (0, 1], memory ≥ 1
+    # the reconciliation options: thresholds in (0, 1], memory ≥ 1
     reconcile = merge(
         d["reconcile"],
-        Dict("inputs" => ["TEMP", "PRES"], "threshold" => 0.75, "lineage" => true, "memory" => 2),
+        Dict(
+            "inputs" => ["TEMP", "PRES"], "match_threshold" => 0.75,
+            "split_threshold" => 0.25, "lineage" => true, "memory" => 2,
+        ),
     )
     _pipeline_schema_validate(schema, reconcile)
-    _pipeline_schema_invalidate(schema, merge(reconcile, Dict("threshold" => 1.5)))
+    _pipeline_schema_invalidate(schema, merge(reconcile, Dict("match_threshold" => 1.5)))
+    _pipeline_schema_invalidate(schema, merge(reconcile, Dict("split_threshold" => 0)))
     _pipeline_schema_invalidate(schema, merge(reconcile, Dict("memory" => 0)))
     # the conjunctive metric is a true metric, so dbscan's field accepts it;
     # radii are positive and required

--- a/Pipelines/test/schemas.jl
+++ b/Pipelines/test/schemas.jl
@@ -69,20 +69,25 @@ end
     _pipeline_schema_validate(schema, d["dbscanCityblock"])
     _pipeline_schema_validate(schema, d["hasPartition"])
     # kmeans seeding is one of Clustering.jl's three strategies
-    _pipeline_schema_invalidate(schema, d["wrongInit"])
+    wrong_init = deepcopy(d["kmeans"])
+    wrong_init["method"]["init"] = "not_an_init"
+    _pipeline_schema_invalidate(schema, wrong_init)
 
+    # the faulty configs live in code: the dissimilarity sits inside `method`,
+    # so the mutation goes through it — a top-level "dissimilarity" key would
+    # be refused as a spurious property before the type were ever looked at
     wrong_dissimilarity = deepcopy(d["kmeansCityblock"])
-    wrong_dissimilarity["dissimilarity"] = Dict("type" => "not_a_dissimilarity")
+    wrong_dissimilarity["method"]["dissimilarity"] = Dict("type" => "not_a_dissimilarity")
     _pipeline_schema_invalidate(schema, wrong_dissimilarity)
 
     # minkowski is a true metric only for p ≥ 1
     wrong_minkowski_p = deepcopy(d["kmeansCityblock"])
-    wrong_minkowski_p["dissimilarity"] = Dict("type" => "minkowski", "p" => 0.5)
+    wrong_minkowski_p["method"]["dissimilarity"] = Dict("type" => "minkowski", "p" => 0.5)
     _pipeline_schema_invalidate(schema, wrong_minkowski_p)
 
     # dbscan accepts true metrics only (KD-tree): sqeuclidean is refused
     wrong_metric = deepcopy(d["dbscanCityblock"])
-    wrong_metric["dissimilarity"] = Dict("type" => "sqeuclidean")
+    wrong_metric["method"]["dissimilarity"] = Dict("type" => "sqeuclidean")
     _pipeline_schema_invalidate(schema, wrong_metric)
 
     wrong_input = merge(d["dbscan"], Dict("inputs" => ["temp", "PRES"]))

--- a/Pipelines/test/schemas.jl
+++ b/Pipelines/test/schemas.jl
@@ -64,10 +64,13 @@ end
     _pipeline_schema_validate(schema, d["kmeans"])
     _pipeline_schema_validate(schema, d["kmeansCityblock"])
     _pipeline_schema_validate(schema, d["kmeansWeighted"])
+    _pipeline_schema_validate(schema, d["kmeansInit"])
     _pipeline_schema_validate(schema, d["dbscan"])
     _pipeline_schema_validate(schema, d["dbscanCityblock"])
     _pipeline_schema_validate(schema, d["hasPartition"])
     _pipeline_schema_invalidate(schema, d["wrongDissimilarity"])
+    # kmeans seeding is one of Clustering.jl's three strategies
+    _pipeline_schema_invalidate(schema, d["wrongInit"])
     # minkowski is a true metric only for p ≥ 1
     _pipeline_schema_invalidate(schema, d["wrongMinkowskiP"])
     # dbscan accepts true metrics only (KD-tree): sqeuclidean is refused

--- a/Pipelines/test/static/configs/cluster.json
+++ b/Pipelines/test/static/configs/cluster.json
@@ -94,16 +94,6 @@
       "init": "rand"
     }
   },
-  "wrongInit": {
-    "type": "cluster",
-    "inputs": ["TEMP", "PRES"],
-    "output": "initcluster",
-    "method": {
-      "type": "kmeans",
-      "classes": 3,
-      "init": "not_an_init"
-    }
-  },
   "reconcile": {
     "type": "cluster",
     "inputs": ["x", "y"],

--- a/Pipelines/test/static/configs/cluster.json
+++ b/Pipelines/test/static/configs/cluster.json
@@ -10,7 +10,8 @@
       "classes": 3,
       "iterations": 100,
       "tol": 1e-6,
-      "seed": 1234
+      "seed": 1234,
+      "init": "kmpp"
     }
   },
   "kmeansCityblock": {
@@ -34,7 +35,8 @@
       "classes": 3,
       "iterations": 100,
       "tol": 1e-6,
-      "seed": 1234
+      "seed": 1234,
+      "init": "kmpp"
     }
   },
   "wrongDissimilarity": {
@@ -106,5 +108,30 @@
       "radius": 0.02
     },
     "partition": "partition"
+  },
+  "kmeansInit": {
+    "type": "cluster",
+    "inputs": ["TEMP", "PRES", "Iws"],
+    "weights": "Iws",
+    "output": "initcluster",
+    "method": {
+      "type": "kmeans",
+      "dissimilarity": { "type": "sqeuclidean" },
+      "classes": 3,
+      "iterations": 100,
+      "tol": 1e-6,
+      "seed": 1234,
+      "init": "rand"
+    }
+  },
+  "wrongInit": {
+    "type": "cluster",
+    "inputs": ["TEMP", "PRES"],
+    "output": "initcluster",
+    "method": {
+      "type": "kmeans",
+      "classes": 3,
+      "init": "not_an_init"
+    }
   }
 }

--- a/Pipelines/test/static/configs/cluster.json
+++ b/Pipelines/test/static/configs/cluster.json
@@ -144,5 +144,21 @@
       "min_neighbors": 2,
       "min_cluster_size": 3
     }
+  },
+  "conjunctive": {
+    "type": "cluster",
+    "inputs": ["x", "y", "z"],
+    "output": "cluster",
+    "method": {
+      "type": "dbscan",
+      "radius": 1.0,
+      "min_neighbors": 3,
+      "min_cluster_size": 3,
+      "dissimilarity": {
+        "type": "conjunctive",
+        "blocks": [1, 1, 2],
+        "radii": [5.0, 60.0]
+      }
+    }
   }
 }

--- a/Pipelines/test/static/configs/cluster.json
+++ b/Pipelines/test/static/configs/cluster.json
@@ -133,5 +133,16 @@
       "classes": 3,
       "init": "not_an_init"
     }
+  },
+  "reconcile": {
+    "type": "cluster",
+    "inputs": ["x", "y"],
+    "output": "cluster",
+    "method": {
+      "type": "dbscan",
+      "radius": 1.0,
+      "min_neighbors": 2,
+      "min_cluster_size": 3
+    }
   }
 }

--- a/docs/src/lib/Pipelines.md
+++ b/docs/src/lib/Pipelines.md
@@ -56,6 +56,17 @@ Pipelines.StreamlinerCard
 Pipelines.WildCard
 ```
 
+## Cluster reconciliation
+
+The cluster card's evaluation refits on its stored members plus the unseen
+rows and reconciles the two clusterings following MONIC's transition model;
+`_relabel_map` is the reconciliation engine — internal, but the semantics of
+cluster identity evolution live there.
+
+```@docs
+Pipelines._relabel_map
+```
+
 ## Card registration
 
 ```@docs


### PR DESCRIPTION
Evaluation of a cluster card no longer re-emits stored labels (nor assigns against a frozen fit): it **refits the method on the stored members plus the rows it has not seen, and reconciles the two clusterings by member overlap**, so a cluster keeps its identity from one evaluation to the next. No assignment rule could achieve this — training is transitive (a point joins, becomes a member, and lets the next point reach the cluster through it) while assignment against a frozen state is one-shot, so a cluster could never grow. This supersedes the per-method predict layer this PR previously proposed; that layer and `kmedoids` are archived in PipelinesExtras' `archived_predicts/` with a reactivation recipe, and can return as their own PR.

## Reconciliation = MONIC's transition model

Labels are matched following MONIC (Spiliopoulou et al., KDD 2006), computed from-old — `overlap(o, n)` is the fraction of stored cluster `o`'s members that landed in refit cluster `n`:

- **survival / absorption** — the best match holds `overlap ≥ match_threshold` (MONIC's τ); several stored clusters matching the same refit cluster is a merge
- **split** — pieces holding `≥ split_threshold` that jointly reach τ are **all** descendants and carry the label
- **disappearance / emergence** — fresh labels continue past the highest ever issued; a forgotten cluster's number is never reused
- `memory` doubles as MONIC's age function in binary form (a TODO marks the recency-weighted refinement); one convention is ours by necessity, since MONIC emits a transition graph rather than labels: a cluster with several ancestors is named by its largest contributor, ties to the lowest label

`_relabel_map` is rendered in the manual under "Cluster reconciliation" — internal, but the semantics of cluster identity evolution live there. All scans run sorted, so results depend on the data alone.

## State and card surface

- Training stores a member table `(id, inputs…, weights?, label, iteration_origin)` as a `SimpleTable` in `CardState.content` (the rescale pattern); `_diagnostics(method, res)` is a per-method opt-in for inspection material
- New options: `match_threshold` (0,1], `split_threshold` (runtime-checked ≤ match_threshold), `lineage::Bool` (roll members forward; an evaluation that admits no rows is a no-op, so re-running one is always safe), `memory` (keep the newest N iterations)
- `node.jl` gains the `_persist_state!` seam: a card may return `(columns, state)` from evaluate; the exactly-typed tuple branch stores the state, anything else passes through untouched — no other card changes behavior

## Conjunctive metric

`ConjunctiveMethod <: MetricMethod` (`"type": "conjunctive"`): `blocks` assigns inputs to blocks, `radii` gives each its radius, distance = max over blocks of within-block Euclidean over the radius — "within 5 km and within 60 minutes" with no exchange rate between units, and a max of metrics is again a metric. dbscan branches on `UnionMinkowskiMetric`: KD-tree for the Minkowski family, precomputed O(N²) matrix for everything else.

## Smaller changes

- Affinity propagation collapses duplicate rows into count weights before the fit (exact reduction; repeated identical points otherwise keep the messages oscillating)
- kmeans exposes Clustering.jl's seeding strategies (`init`: kmpp/rand/kmcen)
- `Bool` card options schematize as `"boolean"` — `Bool <: Integer` made them demand an integer and reject their own value

## Tests

Matcher unit tests, one case per MONIC transition; card-level scenarios on fabricated blobs (no transitions on unchanged data, emergence, lineage on/off, memory without label reuse); conjunctive acceptance criteria including two isometric groups any Minkowski metric must label alike. Field-validated on the internal emergency-call monitor: persistent zones across 24 hours of real data where every previous scheme fragmented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
