### PR TITLE
Make multithreaded column-order test assertions order-insensitive

### DIFF
--- a/Pipelines/test/evaluation.jl
+++ b/Pipelines/test/evaluation.jl
@@ -174,7 +174,8 @@ mktempdir() do dir
         df = DBInterface.execute(DataFrame, repo, "FROM source")
         # order-insensitive: `evaljoin_many` appends independent nodes' columns
         # concurrently, so column order is not deterministic under multithreading.
-        @test sort(names(df)) == sort(
+        @test issetequal(
+            names(df),
             [
                 "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
                 "PRES", "cbwd", "Iws", "Is", "Ir", "_name",

--- a/Pipelines/test/evaluation.jl
+++ b/Pipelines/test/evaluation.jl
@@ -156,12 +156,15 @@ mktempdir() do dir
         df = DBInterface.execute(DataFrame, repo, "FROM selection")
         # order-insensitive: `evaljoin_many` appends independent nodes' columns
         # concurrently, so column order is not deterministic under multithreading.
-        @test sort(names(df)) == sort([
-            "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
-            "PRES", "cbwd", "Iws", "Is", "Ir", "_name",
-            "_percentile_partition", "_tiled_partition",
-            "PRES_rescaled", "TEMP_rescaled",
-        ])
+        @test issetequal(
+            names(df),
+            [
+                "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
+                "PRES", "cbwd", "Iws", "Is", "Ir", "_name",
+                "_percentile_partition", "_tiled_partition",
+                "PRES_rescaled", "TEMP_rescaled",
+            ]
+        )
         @test count(==(1), df._tiled_partition) == 29218
         @test count(==(2), df._tiled_partition) == 14606
         @test count(==(1), df._percentile_partition) == 39441
@@ -171,12 +174,14 @@ mktempdir() do dir
         df = DBInterface.execute(DataFrame, repo, "FROM source")
         # order-insensitive: `evaljoin_many` appends independent nodes' columns
         # concurrently, so column order is not deterministic under multithreading.
-        @test sort(names(df)) == sort([
-            "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
-            "PRES", "cbwd", "Iws", "Is", "Ir", "_name",
-            "_percentile_partition", "_tiled_partition",
-            "PRES_rescaled", "TEMP_rescaled",
-        ])
+        @test sort(names(df)) == sort(
+            [
+                "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
+                "PRES", "cbwd", "Iws", "Is", "Ir", "_name",
+                "_percentile_partition", "_tiled_partition",
+                "PRES_rescaled", "TEMP_rescaled",
+            ]
+        )
         @test count(==(1), df._tiled_partition) == 29218
         @test count(==(2), df._tiled_partition) == 14606
         @test count(==(1), df._percentile_partition) == 39441

--- a/Pipelines/test/evaluation.jl
+++ b/Pipelines/test/evaluation.jl
@@ -154,12 +154,14 @@ mktempdir() do dir
         nodes = Node.(cards)
         Pipelines.train_evaljoin!(repo, nodes, "selection", "No")
         df = DBInterface.execute(DataFrame, repo, "FROM selection")
-        @test names(df) == [
+        # order-insensitive: `evaljoin_many` appends independent nodes' columns
+        # concurrently, so column order is not deterministic under multithreading.
+        @test sort(names(df)) == sort([
             "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
             "PRES", "cbwd", "Iws", "Is", "Ir", "_name",
             "_percentile_partition", "_tiled_partition",
             "PRES_rescaled", "TEMP_rescaled",
-        ]
+        ])
         @test count(==(1), df._tiled_partition) == 29218
         @test count(==(2), df._tiled_partition) == 14606
         @test count(==(1), df._percentile_partition) == 39441
@@ -167,12 +169,14 @@ mktempdir() do dir
 
         Pipelines.evaljoin(repo, nodes, "source", "No")
         df = DBInterface.execute(DataFrame, repo, "FROM source")
-        @test names(df) == [
+        # order-insensitive: `evaljoin_many` appends independent nodes' columns
+        # concurrently, so column order is not deterministic under multithreading.
+        @test sort(names(df)) == sort([
             "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
             "PRES", "cbwd", "Iws", "Is", "Ir", "_name",
             "_percentile_partition", "_tiled_partition",
             "PRES_rescaled", "TEMP_rescaled",
-        ]
+        ])
         @test count(==(1), df._tiled_partition) == 29218
         @test count(==(2), df._tiled_partition) == 14606
         @test count(==(1), df._percentile_partition) == 39441

--- a/Pipelines/test/groups.jl
+++ b/Pipelines/test/groups.jl
@@ -33,9 +33,12 @@ end
     df = DBInterface.execute(DataFrame, repo, "FROM source")
     # order-insensitive: `evaljoin_many` appends independent nodes' columns
     # concurrently, so column order is not deterministic under multithreading.
-    @test sort(names(df)) == sort([
-        "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
-        "PRES", "cbwd", "Iws", "Is", "Ir", "_name", "No_log", "partition",
-        "PRES_rescaled", "TEMP_rescaled", "No_rescaled", "component_1", "component_2",
-    ])
+    @test issetequal(
+        names(df),
+        [
+            "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
+            "PRES", "cbwd", "Iws", "Is", "Ir", "_name", "No_log", "partition",
+            "PRES_rescaled", "TEMP_rescaled", "No_rescaled", "component_1", "component_2",
+        ]
+    )
 end

--- a/Pipelines/test/groups.jl
+++ b/Pipelines/test/groups.jl
@@ -31,9 +31,11 @@ end
     pipeline = Pipelines.Pipeline(d["nodes"], d["groups"])
     Pipelines.train_evaljoin!(repo, pipeline, "source", "No")
     df = DBInterface.execute(DataFrame, repo, "FROM source")
-    @test names(df) == [
+    # order-insensitive: `evaljoin_many` appends independent nodes' columns
+    # concurrently, so column order is not deterministic under multithreading.
+    @test sort(names(df)) == sort([
         "No", "year", "month", "day", "hour", "pm2.5", "DEWP", "TEMP",
         "PRES", "cbwd", "Iws", "Is", "Ir", "_name", "No_log", "partition",
         "PRES_rescaled", "TEMP_rescaled", "No_rescaled", "component_1", "component_2",
-    ]
+    ])
 end


### PR DESCRIPTION
Closes #133.

`evaljoin_many` appends each node's output columns (`ALTER TABLE … ADD COLUMN`)
concurrently via `Threads.foreach`, so the order of columns from independent
nodes depends on which task wins the lock. Tests that assert an exact column
order therefore fail with more than one thread (CI is green because it runs
single-threaded).

This makes the three affected assertions order-insensitive
(`sort(names(df)) == sort([...])`) — at `test/evaluation.jl:157`, `:170`, and
`test/groups.jl:34` — since column output order is not contractual. No source
changes.
